### PR TITLE
API change: use the more idiomatic serve() instead of accept_and_relay()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ tracing = "0.1.40"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"
+tokio = { version = "1.34.0", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time"] }

--- a/README.md
+++ b/README.md
@@ -5,10 +5,20 @@ Fast and easy abstraction for proxying TCP ports.
 [![codecov](https://codecov.io/gh/mtelahun/relayport-rs/branch/main/graph/badge.svg?token=A1P9I5E2LU)](https://codecov.io/gh/mtelahun/relayport-rs)
 [![License](https://img.shields.io/badge/License-BSD_2--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)
 
-## Example
 This library simplifies the creation of asynchronous TCP proxies from rust applications. The only limit on the number
 of proxies are the resources available on the system on which it is run. This library depends on [tokio](https::/tokio.rs)
-for its runtime. A simple program to proxy web traffic to a server might look like this:
+for its runtime.
+
+## Use
+To use this library in your own package add the following to your Cargo.toml:
+
+```
+[dependencies]
+relayport_rs = "0.2.0"
+```
+
+## Example
+A simple program to proxy web traffic to a server might look like this:
 ```
 use std::error::Error;
 use relayport_rs::RelaySocket;
@@ -31,7 +41,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     // spawn a task to handle the acceptance and dispatch of a relay connection
     let _ = tokio::task::spawn(async move {
         relay
-            .accept_and_relay("127.0.0.1:80", &rx)
+            .serve("127.0.0.1:80", &rx)
             .await
             .expect("failed to start relay")
     });
@@ -39,7 +49,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     // Wait for Ctrl-C to send the shutdown command
     let mut sigint = signal(SignalKind::interrupt())?;
     match sigint.recv().await {
-        Some(()) => tx.send(RelayCommand::Shutdown)?,
+        Some(()) => { tx.send(RelayCommand::Shutdown)?; {} },
         None => {},
     }
 
@@ -61,12 +71,4 @@ To insure it was installed correctly type the following commands and make sure y
 ```
 rustc --version
 cargo --version
-```
-
-## Use
-To use this library in your own package add the following to your Cargo.toml:
-
-```
-[dependencies]
-relayport_rs = "0.2.0"
 ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 use std::net::AddrParseError;
 use tokio::sync::broadcast::error::RecvError;
 
-/// The methods of this library may return any of the errors defined here.
+/// relayport-rs may return any of these errors.
 #[derive(Debug)]
 pub enum RelayPortError {
     InternalCommunicationError(RecvError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,12 @@
 //!
 //! # Example
 //! A simple program to proxy web traffic to a server might look like this:
-//! ```
+//! ```no_run
 //! use std::error::Error;
 //! use tokio::sync::broadcast;
 //! use relayport_rs::RelaySocket;
 //! use relayport_rs::command::RelayCommand;
+//! use tokio::signal::unix::{signal, SignalKind};
 //!
 //! #[tokio::main]
 //! pub async fn main() -> Result<(), Box<dyn Error>> {
@@ -27,15 +28,20 @@
 //!     // spawn a task to handle the acceptance and dispatch of a relay connection
 //!     let _ = tokio::task::spawn(async move {
 //!         relay
-//!             .accept_and_relay("127.0.0.1:80", &rx)
+//!             .serve("127.0.0.1:80", &rx)
 //!             .await
 //!             .expect("failed to start relay")
 //!     });
 //!
-//!     // send the task a shutdown command so it exits cleanly
-//!     tx.send(RelayCommand::Shutdown)?;
 //!
-//!     Ok(())
+//!    // Wait for Ctrl-C to send the shutdown command
+//!    let mut sigint = signal(SignalKind::interrupt())?;
+//!    match sigint.recv().await {
+//!        Some(()) => { tx.send(RelayCommand::Shutdown)?; {} },
+//!        None => {},
+//!    }
+//!
+//!    Ok(())
 //! }
 //! ```
 

--- a/src/relay/tcp.rs
+++ b/src/relay/tcp.rs
@@ -287,7 +287,7 @@ impl RelayListener {
     ///     // spawn a task to handle the acceptance and dispatch of a relay
     ///     let _ = tokio::task::spawn(async move {
     ///         listener
-    ///             .accept_and_relay("127.0.0.1:80", &rx)
+    ///             .serve("127.0.0.1:80", &rx)
     ///             .await
     ///             .expect("failed to start relay")
     ///     });
@@ -302,7 +302,7 @@ impl RelayListener {
     /// # }
     ///
     /// ```
-    pub async fn accept_and_relay(
+    pub async fn serve(
         &self,
         peer: &str,
         cancel: &Receiver<RelayCommand>,
@@ -343,10 +343,10 @@ impl RelayListener {
             .await?;
         let handle = tokio::spawn(async move {
             let (mut client_r, mut client_w) = client_stream.split();
-            let (mut relay_r, mut relay_w) = relay.0.split();
+            let (mut remote_r, mut remote_w) = relay.0.split();
             let (xfer_client, xfer_relay) = tokio::join!(
-                relay_inner(&mut client_r, &mut relay_w, cancel.resubscribe()),
-                relay_inner(&mut relay_r, &mut client_w, cancel),
+                relay_inner(&mut client_r, &mut remote_w, cancel.resubscribe()),
+                relay_inner(&mut remote_r, &mut client_w, cancel),
             );
             match xfer_client {
                 Ok(count) => debug!("{count} bytes relayed from client to remote"),

--- a/tests/helpers/bufwrapper.rs
+++ b/tests/helpers/bufwrapper.rs
@@ -1,0 +1,26 @@
+#[derive(Clone, Debug)]
+pub struct BufWrapper {
+    inner: Box<[u8]>,
+}
+
+impl BufWrapper {
+    pub fn new() -> Self {
+        Self {
+            inner: Box::new([0u8; 1518]),
+        }
+    }
+
+    pub fn as_ref(&self) -> &[u8] {
+        &self.inner.as_ref()
+    }
+
+    pub fn as_mut_ref(&mut self) -> &mut [u8] {
+        self.inner.as_mut()
+    }
+
+    pub fn write(&mut self, byte: u8, count: usize) {
+        for i in 0..count {
+            self.inner[i] = byte;
+        }
+    }
+}

--- a/tests/helpers/client.rs
+++ b/tests/helpers/client.rs
@@ -1,0 +1,80 @@
+use relayport_rs::RelayCommand;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    sync::{broadcast::Receiver, oneshot::Sender},
+};
+
+use crate::helpers::bufwrapper::BufWrapper;
+
+#[derive(Debug)]
+pub struct TestClient {
+    remote: String,
+}
+
+impl TestClient {
+    pub fn new(remote: &str) -> Self {
+        Self {
+            remote: remote.to_string(),
+        }
+    }
+
+    pub async fn spawn_reader(
+        self,
+        mut buf: BufWrapper,
+        mut rx: Receiver<RelayCommand>,
+        output: Sender<BufWrapper>,
+    ) {
+        println!("START Client {}: spawn_reader()", self.remote);
+        let remote = self.remote.clone();
+        let _ = tokio::task::spawn(async move {
+            println!("Client connecting to {remote}");
+            let mut stream = TcpStream::connect(remote)
+                .await
+                .expect("client failed to connect to server");
+            loop {
+                let count;
+                println!("Client reader: reading from socket");
+                tokio::select! {
+                    biased;
+                    result = stream.read(buf.as_mut_ref()) => {
+                        count = result.or_else(|e| match e.kind() {
+                            _ => { println!("failed to read from tcp stream: {}", e); Err(e) }
+                        }).expect("Server: failed to read from socket");
+                    },
+                    _ = rx.recv() => { println!("Server: recieved cancel signal"); break; }
+                }
+
+                if count == 0 {
+                    println!("Client reader: received 0 bytes");
+                    break;
+                } else {
+                    println!("Client reader: received {count} bytes");
+                    break;
+                }
+            }
+            output.send(buf).expect("failed to send received buffer");
+        });
+    }
+
+    pub async fn spawn_writer(&self, buf: BufWrapper) {
+        println!("START Server {}: spawn_writer()", self.remote);
+        let remote = self.remote.clone();
+        let _ = tokio::task::spawn(async move {
+            println!("Client connecting to {remote}");
+            let mut stream = TcpStream::connect(&remote)
+                .await
+                .expect("client failed to connect to server");
+            let _ = stream
+                .write_all(buf.as_ref())
+                .await
+                .expect("write to server socket failed");
+            let _ = stream
+                .flush()
+                .await
+                .expect("Client: failed to flush the buffer to the socket");
+            println!("Client {remote}: wrote buffer");
+            let _ = stream.shutdown().await;
+        });
+    }
+}

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,0 +1,4 @@
+pub mod bufwrapper;
+pub mod client;
+pub mod relay;
+pub mod server;

--- a/tests/helpers/relay.rs
+++ b/tests/helpers/relay.rs
@@ -1,0 +1,39 @@
+use relayport_rs::{RelayCommand, RelaySocket};
+use tokio::sync::broadcast::Receiver;
+
+#[derive(Clone, Debug)]
+pub struct Relay {
+    bind_addr: String,
+    remote: String,
+}
+
+impl Relay {
+    pub fn new(bind_addr: &str, remote: &str) -> Self {
+        Self {
+            bind_addr: bind_addr.to_string(),
+            remote: remote.to_string(),
+        }
+    }
+
+    pub async fn spawn(&self, rx: Receiver<RelayCommand>) {
+        println!("START spawn_relay()");
+        let listen_addr = self.bind_addr.clone();
+        let relay_addr = self.remote.clone();
+        let relay = RelaySocket::build()
+            .set_so_reuseaddr(true)
+            .set_tcp_nodelay(true)
+            .bind(&listen_addr)
+            .expect(&format!("failed to bind to {}", listen_addr))
+            .listen()
+            .expect(&format!(
+                "failed to listen to bound address: {}",
+                listen_addr
+            ));
+        let _ = tokio::task::spawn(async move {
+            relay
+                .serve(&relay_addr, &rx)
+                .await
+                .expect("failed to start relay")
+        });
+    }
+}

--- a/tests/helpers/server.rs
+++ b/tests/helpers/server.rs
@@ -1,0 +1,86 @@
+use relayport_rs::RelayCommand;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    sync::{broadcast::Receiver, oneshot::Sender},
+};
+
+use crate::helpers::bufwrapper::BufWrapper;
+
+#[derive(Debug)]
+pub struct TestServer {
+    bind_addr: String,
+}
+
+impl TestServer {
+    pub fn new(addr: &str) -> Self {
+        Self {
+            bind_addr: addr.to_string(),
+        }
+    }
+
+    pub async fn spawn_reader(
+        &self,
+        mut buf: BufWrapper,
+        mut rx: Receiver<RelayCommand>,
+        output: Sender<BufWrapper>,
+    ) {
+        println!("START Server {}: spawn_reader()", self.bind_addr);
+        let addr = self.bind_addr.clone();
+        tokio::task::spawn(async move {
+            println!("Server listening on {addr}");
+            let listener = TcpListener::bind(&addr)
+                .await
+                .expect(&format!("test server failed to bind to {}", addr));
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("listening server failed to accept incomming connection");
+            println!("Server {addr}: accepted connection");
+            loop {
+                let count;
+                println!("Server {addr}: reading from socket");
+                tokio::select! {
+                    biased;
+                    result = stream.read(buf.as_mut_ref()) => {
+                        count = result.or_else(|e| match e.kind() {
+                            _ => { println!("failed to read from tcp stream: {}", e); Err(e) }
+                        }).expect("Server: failed to read from socket");
+                    },
+                    _ = rx.recv() => { println!("Server {addr}: recieved cancel signal"); break; }
+                }
+
+                if count == 0 {
+                    println!("Server {addr}: received 0 bytes");
+                    break;
+                } else {
+                    println!("Server {addr}: received {count} bytes");
+                    break;
+                }
+            }
+            output.send(buf).expect("failed to send received buffer");
+        });
+    }
+
+    pub async fn spawn_writer(&self, buf: BufWrapper) {
+        println!("START Server {}: spawn_writer()", self.bind_addr);
+        let addr = self.bind_addr.clone();
+        tokio::task::spawn(async move {
+            println!("Server listening on {addr}");
+            let listener = TcpListener::bind(&addr)
+                .await
+                .expect(&format!("test server failed to bind to {}", addr));
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("listening server failed to accept incomming connection");
+            println!("Server {addr}: accepted connection");
+            let _ = stream
+                .write_all(buf.as_ref())
+                .await
+                .expect("write to server socket failed");
+            println!("Server {addr}: wrote buffer");
+            let _ = stream.shutdown().await;
+        });
+    }
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,149 +1,87 @@
-use relayport_rs::{command::RelayCommand, RelaySocket};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
-    sync::{
-        broadcast::{self, Receiver},
-        oneshot,
-    },
+use relayport_rs::RelayCommand;
+use tokio::sync::{broadcast, oneshot};
+
+use crate::helpers::{
+    bufwrapper::BufWrapper, client::TestClient, relay::Relay, server::TestServer,
 };
-use tracing::{debug, info};
-use tracing_subscriber;
 
-#[derive(Clone, Debug)]
-pub struct BufWrapper {
-    inner: Box<[u8]>,
-}
-
-impl BufWrapper {
-    pub fn new() -> Self {
-        Self {
-            inner: Box::new([0u8; 1518]),
-        }
-    }
-
-    pub fn as_ref(&self) -> &[u8] {
-        &self.inner.as_ref()
-    }
-
-    pub fn as_mut_ref(&mut self) -> &mut [u8] {
-        self.inner.as_mut()
-    }
-
-    pub fn write(&mut self, byte: u8, count: usize) {
-        for i in 0..count {
-            self.inner[i] = byte;
-        }
-    }
-}
-
-async fn spawn_server(
-    mut buf: BufWrapper,
-    mut rx: Receiver<RelayCommand>,
-    output: tokio::sync::oneshot::Sender<BufWrapper>,
-) {
-    debug!("START spawn_server()");
-    let addr = "127.0.0.1:20100";
-    tokio::task::spawn(async move {
-        debug!("Server listening on {addr}");
-        let listener = TcpListener::bind(&addr)
-            .await
-            .expect(&format!("test server failed to bind to {}", addr));
-        let (mut stream, _) = listener
-            .accept()
-            .await
-            .expect("listening server failed to accept incomming connection");
-        debug!("Server: accepted connection");
-        loop {
-            let count;
-            debug!("Server: reading from socket");
-            tokio::select! {
-                biased;
-                result = stream.read(buf.as_mut_ref()) => {
-                    count = result.or_else(|e| match e.kind() {
-                        _ => { info!("failed to read from tcp stream: {}", e); Err(e) }
-                    }).expect("Server: failed to read from socket");
-                },
-                _ = rx.recv() => { debug!("Server: recieved cancel signal"); break; }
-            }
-
-            if count == 0 {
-                debug!("Server: received 0 bytes");
-                break;
-            } else {
-                debug!("Server: received {count} bytes");
-                break;
-            }
-        }
-        output.send(buf).expect("failed to send received buffer");
-    });
-}
-
-async fn spawn_relay(rx: Receiver<RelayCommand>) {
-    debug!("START spawn_relay()");
-    let listen_addr = "127.0.0.1:10099";
-    let relay_addr = "127.0.0.1:20100";
-    let relay = RelaySocket::build()
-        .set_so_reuseaddr(true)
-        .set_tcp_nodelay(true)
-        .bind(listen_addr)
-        .expect(&format!("failed to bind to {}", listen_addr))
-        .listen()
-        .expect(&format!(
-            "failed to listen to bound address: {}",
-            listen_addr
-        ));
-    let _ = tokio::task::spawn(async move {
-        relay
-            .accept_and_relay(relay_addr, &rx)
-            .await
-            .expect("failed to start relay")
-    });
-}
-
-async fn spawn_client(buf: BufWrapper) {
-    debug!("START spawn_client()");
-    let remote = "127.0.0.1:10099";
-    let _ = tokio::task::spawn(async move {
-        debug!("Client connecting to {remote}");
-        let mut stream = TcpStream::connect(remote)
-            .await
-            .expect("client failed to connect to server");
-        let _ = stream
-            .write_all(buf.as_ref())
-            .await
-            .expect("write to server socket failed");
-        let _ = stream
-            .flush()
-            .await
-            .expect("Client: failed to flush the buffer to the socket");
-        debug!("Client: wrote buffer");
-        let _ = stream.shutdown().await;
-    });
-}
+pub mod helpers;
 
 #[tokio::test]
 async fn client_to_server() {
-    tracing_subscriber::fmt::init();
     let (tx, rx) = broadcast::channel(1);
-    let (output_sender, output_receiver) = oneshot::channel::<BufWrapper>();
-    let mut buf_client = BufWrapper::new();
-    buf_client.write(56u8, 100);
-    let buf_server = BufWrapper::new();
-    spawn_server(buf_server, tx.subscribe(), output_sender).await;
-    spawn_relay(rx).await;
-    spawn_client(buf_client.clone()).await;
+    let mut buf_write = BufWrapper::new();
+    buf_write.write(56u8, 100);
+    let buf_read = BufWrapper::new();
 
-    let buf_server = output_receiver
+    let output_receiver = spawn_all(
+        "127.0.0.1:10099",
+        "127.0.0.1:20100",
+        buf_read,
+        buf_write.clone(),
+        rx,
+    )
+    .await;
+
+    let buf_result = output_receiver
         .await
         .expect("failed to receive server buffer");
-
-    println!("Sending shutdown cmd ...");
+    println!("client_to_server: Sending shutdown cmd ...");
     tx.send(RelayCommand::Shutdown)
         .expect("failed to send shutdown command to relay");
 
     assert_eq!(
-        buf_server.as_ref(),
-        buf_client.as_ref(),
+        buf_result.as_ref(),
+        buf_write.as_ref(),
         "The contents of the buffer received by the server are identical to that sent by the client");
+}
+
+#[tokio::test]
+async fn server_to_client() {
+    let (tx, rx) = broadcast::channel(1);
+    let mut buf_write = BufWrapper::new();
+    buf_write.write(56u8, 100);
+    let buf_read = BufWrapper::new();
+
+    let output_receiver = spawn_all(
+        "127.0.0.1:11099",
+        "127.0.0.1:21100",
+        buf_read,
+        buf_write.clone(),
+        rx,
+    )
+    .await;
+
+    let buf_result = output_receiver
+        .await
+        .expect("failed to receive output buffer");
+
+    println!("server_to_client: Sending shutdown cmd ...");
+    tx.send(RelayCommand::Shutdown)
+        .expect("failed to send shutdown command to relay");
+
+    assert_eq!(
+        buf_result.as_ref(),
+        buf_write.as_ref(),
+        "The contents of the buffer received by the client are identical to that sent by the server");
+}
+
+async fn spawn_all(
+    relay_addr: &str,
+    server_addr: &str,
+    buf_read: BufWrapper,
+    buf_write: BufWrapper,
+    rx: tokio::sync::broadcast::Receiver<RelayCommand>,
+) -> tokio::sync::oneshot::Receiver<BufWrapper> {
+    let (output_sender, output_receiver) = oneshot::channel::<BufWrapper>();
+    let client = TestClient::new(relay_addr);
+    let relay = Relay::new(relay_addr, server_addr);
+    let server = TestServer::new(server_addr);
+    server
+        .spawn_reader(buf_read, rx.resubscribe(), output_sender)
+        .await;
+    relay.spawn(rx).await;
+    client.spawn_writer(buf_write).await;
+
+    output_receiver
 }


### PR DESCRIPTION
- Includes test refactoring